### PR TITLE
No longer needing a forked ros_control

### DIFF
--- a/examples/interactive_grasping_simulatior/package.xml
+++ b/examples/interactive_grasping_simulatior/package.xml
@@ -13,7 +13,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>soft_hand</run_depend>
+  <run_depend>soft_hand_description</run_depend>
+  <run_depend>soft_hand_ros_control</run_depend>
 
   <export>
   </export>

--- a/examples/two_hands_example/launch/two_hands.launch
+++ b/examples/two_hands_example/launch/two_hands.launch
@@ -104,8 +104,10 @@
         <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="true" output="screen"  args="joint_state_controller joint_trajectory_controller"/>
 
         <!-- grasp estimator -->
-        <rosparam command="load" file="$(find grasp_state_publisher)/config/softgrasp.yaml" />
-        <node name="grasp_state_publisher" pkg="grasp_state_publisher" type="grasp_state_publisher" respawn="true" output="screen" />
+        <group if="$(arg use_grasp_estimator)">
+            <rosparam command="load" file="$(find grasp_state_publisher)/config/softgrasp.yaml" />
+            <node name="grasp_state_publisher" pkg="grasp_state_publisher" type="grasp_state_publisher" respawn="true" output="screen" />
+        </group>
     </group>
 
 </launch>

--- a/gazebo_ros_soft_hand/CMakeLists.txt
+++ b/gazebo_ros_soft_hand/CMakeLists.txt
@@ -45,14 +45,30 @@ catkin_package(
 )
 
 ## Libraries
+add_library(adaptive_transmission_loader_plugin
+  src/adaptive_synergy_transmission_loader.cpp
+)
+add_dependencies(adaptive_transmission_loader_plugin transmission_interface_loader)
+target_link_libraries(adaptive_transmission_loader_plugin ${catkin_LIBRARIES})
+
 add_library(${PROJECT_NAME} src/gazebo_ros_soft_hand_plugin.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 
 add_library(default_soft_hand_hw_sim src/default_soft_hand_hw_sim.cpp)
-target_link_libraries(default_soft_hand_hw_sim ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+add_dependencies(default_soft_hand_hw_sim
+    adaptive_transmission_loader_plugin
+)
+target_link_libraries(default_soft_hand_hw_sim ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES}
+    adaptive_transmission_loader_plugin
+)
 
 add_library(kinematic_ctrl_soft_hand_hw_sim src/kinematic_ctrl_soft_hand_hw_sim.cpp)
-target_link_libraries(kinematic_ctrl_soft_hand_hw_sim ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+add_dependencies(kinematic_ctrl_soft_hand_hw_sim
+    adaptive_transmission_loader_plugin
+)
+target_link_libraries(kinematic_ctrl_soft_hand_hw_sim ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES}
+    adaptive_transmission_loader_plugin
+)
 
 ## Install
 install(TARGETS ${PROJECT_NAME} default_soft_hand_hw_sim

--- a/gazebo_ros_soft_hand/CMakeLists.txt
+++ b/gazebo_ros_soft_hand/CMakeLists.txt
@@ -87,6 +87,10 @@ install(FILES soft_hand_hw_sim_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   )
 
+install(FILES adaptive_transmission_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  )
+
 #############
 ## Testing ##
 #############

--- a/gazebo_ros_soft_hand/CMakeLists.txt
+++ b/gazebo_ros_soft_hand/CMakeLists.txt
@@ -86,3 +86,17 @@ install(DIRECTORY include/${PROJECT_NAME}/
 install(FILES soft_hand_hw_sim_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   )
+
+#############
+## Testing ##
+#############
+
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(adaptive_synergy_transmission_test test/adaptive_synergy_transmission_test.cpp)
+
+  catkin_add_gtest(adaptive_synergy_transmission_loader_test test/adaptive_synergy_transmission_loader_test.cpp)
+  target_link_libraries(adaptive_synergy_transmission_loader_test
+    ${catkin_LIBRARIES}
+    adaptive_transmission_loader_plugin
+  )
+endif()

--- a/gazebo_ros_soft_hand/adaptive_transmission_plugin.xml
+++ b/gazebo_ros_soft_hand/adaptive_transmission_plugin.xml
@@ -1,0 +1,12 @@
+<library path="lib/libadaptive_transmission_loader_plugin">
+
+  <!-- Transmission types -->
+  <class name="transmission_interface/AdaptiveSynergyTransmission"
+         type="transmission_interface::AdaptiveSynergyTransmissionLoader"
+         base_class_type="transmission_interface::TransmissionLoader">
+    <description>
+      Load from a URDF description the configuration of an adaptive synergy transmission.
+    </description>
+  </class>
+
+</library>

--- a/gazebo_ros_soft_hand/adaptive_transmission_plugin.xml
+++ b/gazebo_ros_soft_hand/adaptive_transmission_plugin.xml
@@ -1,8 +1,8 @@
 <library path="lib/libadaptive_transmission_loader_plugin">
 
   <!-- Transmission types -->
-  <class name="transmission_interface/AdaptiveSynergyTransmission"
-         type="transmission_interface::AdaptiveSynergyTransmissionLoader"
+  <class name="adaptive_transmission_interface/AdaptiveSynergyTransmission"
+         type="adaptive_transmission_interface::AdaptiveSynergyTransmissionLoader"
          base_class_type="transmission_interface::TransmissionLoader">
     <description>
       Load from a URDF description the configuration of an adaptive synergy transmission.

--- a/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission.h
@@ -1,0 +1,389 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2014, Research Center "E. Piaggio"
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// \author Adolfo Rodriguez Tsouroukdissian
+
+// \author Carlos Rosales, based on templates of other transmissions
+
+#ifndef TRANSMISSION_INTERFACE_ADAPTIVE_SYNERGY_TRANSMISSION_H
+#define TRANSMISSION_INTERFACE_ADAPTIVE_SYNERGY_TRANSMISSION_H
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include <transmission_interface/transmission.h>
+#include <transmission_interface/transmission_interface_exception.h>
+
+namespace transmission_interface
+{
+
+/**
+* \brief Implementation of an adaptive synergy transmission.
+* ToDo: Write documentation
+*
+*
+* \ingroup transmission_types
+*/
+class AdaptiveSynergyTransmission : public Transmission
+{
+public:
+  /**
+* \param actuator_reduction Reduction ratio of actuators.
+* \param joint_reduction    Reduction ratio of joints, it is a vector 19x1.
+* \param joint_elastic      Spring constants of joints, it is a diagonal matrix 19x19; we simplified by a vetor 19x1.
+* \param joint_offset       Joint position offset used in the position mappings, it is a vector of 19x1.
+* \pre Nonzero actuator and joint reduction values.
+*/
+  AdaptiveSynergyTransmission(const std::vector<double>& actuator_reduction,
+                              const std::vector<double>& joint_reduction,
+                              const std::vector<double>& joint_elastic,
+                              const std::vector<double>& joint_offset = std::vector<double>(19, 0.0));
+
+  /**
+* \brief Transform \e effort variables from actuator to joint space.
+* \param[in] act_data Actuator-space variables.
+* \param[out] jnt_data Joint-space variables.
+* \pre Actuator and joint effort vectors must have size 2 and point to valid data.
+* To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
+*/
+  void actuatorToJointEffort(const ActuatorData& act_data, JointData& jnt_data);
+
+  /**
+* \brief Transform \e velocity variables from actuator to joint space.
+* \param[in] act_data Actuator-space variables.
+* \param[out] jnt_data Joint-space variables.
+* \pre Actuator and joint velocity vectors must have size 2 and point to valid data.
+* To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
+*/
+
+ void actuatorToJointVelocity(const ActuatorData& act_data, JointData& jnt_data);
+
+  /**
+* \brief Transform \e position variables from actuator to joint space.
+* \param[in] act_data Actuator-space variables.
+* \param[out] jnt_data Joint-space variables.
+* \pre Actuator and joint position vectors must have size 2 and point to valid data.
+* To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
+*/
+  void actuatorToJointPosition(const ActuatorData& act_data, JointData& jnt_data);
+
+  /**
+* \brief Transform \e effort variables from joint to actuator space.
+* \param[in] jnt_data Joint-space variables.
+* \param[out] act_data Actuator-space variables.
+* \pre Actuator and joint effort vectors must have size 2 and point to valid data.
+* To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
+*/
+  void jointToActuatorEffort(const JointData& jnt_data, ActuatorData& act_data);
+
+  /**
+* \brief Transform \e velocity variables from joint to actuator space.
+* \param[in] jnt_data Joint-space variables.
+* \param[out] act_data Actuator-space variables.
+* \pre Actuator and joint velocity vectors must have size 2 and point to valid data.
+* To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
+*/
+  void jointToActuatorVelocity(const JointData& jnt_data, ActuatorData& act_data);
+
+  /**
+* \brief Transform \e position variables from joint to actuator space.
+* \param[in] jnt_data Joint-space variables.
+* \param[out] act_data Actuator-space variables.
+* \pre Actuator and joint position vectors must have size 2 and point to valid data.
+* To call this method it is not required that all other data vectors contain valid data, and can even remain empty.
+*/
+  
+  void jointToActuatorPosition(const JointData& jnt_data, ActuatorData& act_data);
+
+  std::size_t numActuators() const {return 1;}      // we have 1 actuator
+  std::size_t numJoints() const {return 19;}      // we have 19 joint distibuted over 5 fingers
+  
+  const std::vector<double>& getActuatorReduction() const {return act_reduction_;}      // is a vector 19x1
+  const std::vector<double>& getJointReduction() const {return jnt_reduction_;}  // is a vector 1x19
+  const std::vector<double>& getJointElastic() const {return jnt_elastic_;}  // is a vector 19x1
+  const std::vector<double>& getJointOffset() const {return jnt_offset_;} // is a vector 19x1, but useless for now
+
+protected:
+  std::vector<double> act_reduction_;
+  std::vector<double> jnt_reduction_;
+  std::vector<double> jnt_elastic_;
+  std::vector<double> jnt_offset_;
+  
+};
+
+inline AdaptiveSynergyTransmission::AdaptiveSynergyTransmission(const std::vector<double>& actuator_reduction,
+                                                                const std::vector<double>& joint_reduction,
+                                                                const std::vector<double>& joint_elastic,
+                                                                const std::vector<double>& joint_offset)
+  : Transmission(),
+    act_reduction_(actuator_reduction),
+    jnt_reduction_(joint_reduction),
+    jnt_elastic_(joint_elastic),
+    jnt_offset_(joint_offset)
+{
+  if (numActuators() != act_reduction_.size() ||
+      numJoints() != jnt_reduction_.size() ||
+      numJoints() != jnt_elastic_.size() ||
+      numJoints() != jnt_offset_.size())
+  {
+    throw TransmissionInterfaceException("Array of a adaptive sinergy transmission must has size 19x1 and actuator has size 1.");
+  }
+
+  if (0.0 == act_reduction_[0] ||
+      0.0 == jnt_reduction_[0] ||
+      0.0 == jnt_reduction_[1] ||
+      0.0 == jnt_reduction_[2] ||
+      0.0 == jnt_reduction_[3] ||
+      0.0 == jnt_reduction_[4] ||
+      0.0 == jnt_reduction_[5] ||
+      0.0 == jnt_reduction_[6] ||
+      0.0 == jnt_reduction_[7] ||
+      0.0 == jnt_reduction_[8] ||
+      0.0 == jnt_reduction_[9] ||
+      0.0 == jnt_reduction_[10] ||
+      0.0 == jnt_reduction_[11] ||
+      0.0 == jnt_reduction_[12] ||
+      0.0 == jnt_reduction_[13] ||
+      0.0 == jnt_reduction_[14] ||
+      0.0 == jnt_reduction_[15] ||
+      0.0 == jnt_reduction_[16] ||
+      0.0 == jnt_reduction_[17] ||
+      0.0 == jnt_reduction_[18] ||
+      0.0 == jnt_elastic_[0] ||
+      0.0 == jnt_elastic_[1] ||
+      0.0 == jnt_elastic_[2] ||
+      0.0 == jnt_elastic_[3] ||
+      0.0 == jnt_elastic_[4] ||
+      0.0 == jnt_elastic_[5] ||
+      0.0 == jnt_elastic_[6] ||
+      0.0 == jnt_elastic_[7] ||
+      0.0 == jnt_elastic_[8] ||
+      0.0 == jnt_elastic_[9] ||
+      0.0 == jnt_elastic_[10] ||
+      0.0 == jnt_elastic_[11] ||
+      0.0 == jnt_elastic_[12] ||
+      0.0 == jnt_elastic_[13] ||
+      0.0 == jnt_elastic_[14] ||
+      0.0 == jnt_elastic_[15] ||
+      0.0 == jnt_elastic_[16] ||
+      0.0 == jnt_elastic_[17] ||
+      0.0 == jnt_elastic_[18]
+  ) 
+ 
+  {
+    throw TransmissionInterfaceException("Transmission reduction ratios cannot be zero.");
+  }
+}
+
+inline void AdaptiveSynergyTransmission::actuatorToJointEffort(const ActuatorData& act_data,
+                                                                     JointData& jnt_data)
+{
+  assert(numActuators() == act_data.effort.size());
+  assert(numJoints() == jnt_data.position.size());
+  assert(numJoints() == jnt_data.effort.size());
+  assert(act_data.effort[0] && jnt_data.position[0]  && jnt_data.position[1]  && jnt_data.position[2]  && jnt_data.position[3]
+                            && jnt_data.position[4]  && jnt_data.position[5]  && jnt_data.position[6]  && jnt_data.position[7]
+                            && jnt_data.position[8]  && jnt_data.position[9]  && jnt_data.position[10] && jnt_data.position[11]
+                            && jnt_data.position[12] && jnt_data.position[13] && jnt_data.position[14] && jnt_data.position[15]
+                            && jnt_data.position[16] && jnt_data.position[17] && jnt_data.position[18]);
+
+  std::vector<double>& ar = act_reduction_;
+  std::vector<double>& jr = jnt_reduction_;
+  std::vector<double>& je = jnt_elastic_;
+  
+  // tau_q =    R'  * tau_m -    E   *  q;
+  // 19x1 = ( 19x1 *  1x1) - (19x19 * 19x1)
+/*
+  for(int i = 0; i < je.size() ; ++i)
+  {
+    *jnt_data.effort[i]  =  jr[i]*(ar[0] * (*act_data.effort[0])) - je[i]  * (*jnt_data.position[i]);
+  }
+*/
+  for(int i = 0; i < je.size() ; ++i)
+  {
+    *jnt_data.effort[i]  =  jr[i]*(ar[0] * (*act_data.effort[0])) - je[i]  * (*jnt_data.position[i]);
+  }
+}
+
+inline void AdaptiveSynergyTransmission::actuatorToJointVelocity(const ActuatorData& act_data,
+                                                                       JointData& jnt_data)
+{
+  assert(numActuators() == act_data.velocity.size());
+  assert(numJoints() == jnt_data.velocity.size());
+  assert(act_data.velocity[0]);
+
+  std::vector<double>& ar = act_reduction_;
+  std::vector<double>& jr = jnt_reduction_;
+  std::vector<double>& je = jnt_elastic_;
+
+  // ToDo: this mapping is to be developed, perhaps it is not necessary if the hand is always controlled in position/effort
+  *jnt_data.velocity[0] =  0.0;
+  *jnt_data.velocity[1] =  0.0;
+  *jnt_data.velocity[2] =  0.0;
+  *jnt_data.velocity[3] =  0.0;
+  *jnt_data.velocity[4] =  0.0;
+  *jnt_data.velocity[5] =  0.0;
+  *jnt_data.velocity[6] =  0.0;
+  *jnt_data.velocity[7] =  0.0;
+  *jnt_data.velocity[8] =  0.0;
+  *jnt_data.velocity[9] =  0.0;
+  *jnt_data.velocity[10] = 0.0;
+  *jnt_data.velocity[11] = 0.0;
+  *jnt_data.velocity[12] = 0.0;
+  *jnt_data.velocity[13] = 0.0;
+  *jnt_data.velocity[14] = 0.0;
+  *jnt_data.velocity[15] = 0.0;
+  *jnt_data.velocity[16] = 0.0;
+  *jnt_data.velocity[17] = 0.0;
+  *jnt_data.velocity[18] = 0.0;
+}
+
+inline void AdaptiveSynergyTransmission::actuatorToJointPosition(const ActuatorData& act_data,
+                                                                    JointData&    jnt_data)
+{
+  assert(numActuators() == act_data.position.size());
+  assert(numJoints() == jnt_data.effort.size());
+  assert(numJoints() == jnt_data.position.size());
+  assert(act_data.position[0] && jnt_data.effort[0]  && jnt_data.effort[1]  && jnt_data.effort[2]  && jnt_data.effort[3]
+                              && jnt_data.effort[4]  && jnt_data.effort[5]  && jnt_data.effort[6]  && jnt_data.effort[7]
+                              && jnt_data.effort[8]  && jnt_data.effort[9]  && jnt_data.effort[10] && jnt_data.effort[11]
+                              && jnt_data.effort[12] && jnt_data.effort[13] && jnt_data.effort[14] && jnt_data.effort[15]
+                              && jnt_data.effort[16] && jnt_data.effort[17] && jnt_data.effort[18] );
+
+  std::vector<double>& ar = act_reduction_;
+  std::vector<double>& jr = jnt_reduction_;
+  std::vector<double>& je = jnt_elastic_;
+  
+  // E^-1 * R^t
+  std::vector<double> EinvRtr( je.size() );
+
+  // (R * E^-1 * R^t)^-1
+  double REinvRtr = 0.0;
+  double REinvRtr_inv = 0.0;
+
+  // R * E^-1 * tau_q
+  double REinvTau_q = 0.0;
+  
+  // -E^-1 * tau_q
+  std::vector<double> EinvTau_q( je.size() );
+  
+  // build auxiliary terms  
+  for( int i = 0 ; i < je.size() ; ++i )
+  {
+    EinvTau_q[i] = (*jnt_data.effort[i]) / je[i];
+    REinvTau_q += ( jr[i]/je[i] ) * (*jnt_data.effort[i]);
+    EinvRtr[i] = jr[i]/je[i];
+    REinvRtr += (jr[i]*jr[i])/je[i];
+  }
+
+  REinvRtr_inv = 1/REinvRtr;
+
+  // first and second terms
+  double first_term;
+  double second_term;
+
+  for( int i = 0; i < je.size() ; ++i)
+  {
+    first_term = -1*EinvTau_q[i] + EinvRtr[i]*REinvRtr_inv*REinvTau_q;
+    second_term = EinvRtr[i]*REinvRtr_inv* (*act_data.position[0] / ar[0]);
+
+    *jnt_data.position[i] = first_term + second_term + (jnt_offset_[i]);
+  }
+}
+
+inline void AdaptiveSynergyTransmission::jointToActuatorEffort(const JointData& jnt_data,
+                                                                     ActuatorData& act_data)
+{
+  assert(numActuators() == act_data.position.size());
+  assert(numActuators() == act_data.effort.size());
+  assert(numJoints() == jnt_data.effort.size());
+  assert(act_data.position[0] && jnt_data.effort[0]  && jnt_data.effort[1]  && jnt_data.effort[2]  && jnt_data.effort[3]
+                              && jnt_data.effort[4]  && jnt_data.effort[5]  && jnt_data.effort[6]  && jnt_data.effort[7]
+                              && jnt_data.effort[8]  && jnt_data.effort[9]  && jnt_data.effort[10] && jnt_data.effort[11]
+                              && jnt_data.effort[12] && jnt_data.effort[13] && jnt_data.effort[14] && jnt_data.effort[15]
+                              && jnt_data.effort[16] && jnt_data.effort[17] && jnt_data.effort[18]);
+
+  std::vector<double>& ar = act_reduction_;
+  std::vector<double>& jr = jnt_reduction_;
+  std::vector<double>& je = jnt_elastic_;
+
+  // (R * E^-1 * R^t)^-1
+  double REinvRtr = 0.0;
+  double REinvRtr_inv = 0.0;
+  // R * E^-1 * tau_q
+  double REinvTau_q = 0.0;
+  
+  for( int i = 0 ; i < je.size() ; ++i )
+  {
+    REinvTau_q += ( jr[i]/je[i] ) * (*jnt_data.effort[i]);
+    REinvRtr += (jr[i]*jr[i])/je[i];
+  }
+
+  REinvRtr_inv = 1/REinvRtr;
+
+  // tau_a = (...)*tau_q + (...)*pos_a
+  *act_data.effort[0] = REinvRtr_inv * ( REinvTau_q + (*act_data.position[0])*ar[0]);
+}
+
+inline void AdaptiveSynergyTransmission::jointToActuatorVelocity(const JointData&    jnt_data,
+                                                                    ActuatorData& act_data)
+{
+  // The actuator does not move if the fingers are moved
+  *act_data.velocity[0] = 0.0;
+}
+
+inline void AdaptiveSynergyTransmission::jointToActuatorPosition(const JointData&    jnt_data,
+                                                                    ActuatorData& act_data)
+{
+  assert(numActuators() == act_data.position.size());
+  assert(numJoints() == jnt_data.position.size());
+  assert(act_data.position[0] && jnt_data.position[0]  && jnt_data.position[1]  && jnt_data.position[2]  && jnt_data.position[3]
+                              && jnt_data.position[4]  && jnt_data.position[5]  && jnt_data.position[6]  && jnt_data.position[7]
+                              && jnt_data.position[8]  && jnt_data.position[9]  && jnt_data.position[10] && jnt_data.position[11]
+                              && jnt_data.position[12] && jnt_data.position[13] && jnt_data.position[14] && jnt_data.position[15]
+                              && jnt_data.position[16] && jnt_data.position[17] && jnt_data.position[18]);
+
+  std::vector<double>& ar = act_reduction_;
+  std::vector<double>& jr = jnt_reduction_;
+  std::vector<double>& je = jnt_elastic_;
+  
+  *act_data.position[0] = 0.0;
+
+  // R * q = s, for suitable matrices, s = actuator position
+  // in summary, this constraint is similar to make a constant length wire
+
+  for( int i = 0 ; i < je.size() ; ++i )
+  {
+    *act_data.position[0] += ( jr[i]*(*jnt_data.position[i] - jnt_offset_[i]) ) * ar[0];
+  }
+}
+
+} // transmission_interface
+
+#endif // TRANSMISSION_INTERFACE_ADAPTIVE_SYNERGY_TRANSMISSION_H

--- a/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission.h
@@ -40,8 +40,10 @@
 #include <transmission_interface/transmission.h>
 #include <transmission_interface/transmission_interface_exception.h>
 
-namespace transmission_interface
+namespace adaptive_transmission_interface
 {
+
+using namespace transmission_interface;
 
 /**
 * \brief Implementation of an adaptive synergy transmission.

--- a/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission_loader.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission_loader.h
@@ -39,8 +39,10 @@
 // ros_control
 #include <transmission_interface/transmission_loader.h>
 
-namespace transmission_interface
+namespace adaptive_transmission_interface
 {
+
+using namespace transmission_interface;
 
 /**
  * \brief Class for loading a Adaptive Synergy transmission instance from configuration data.

--- a/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission_loader.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission_loader.h
@@ -1,0 +1,72 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2014, Research Center "E. Piaggio"
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// \author Adolfo Rodriguez Tsouroukdissian
+
+// \author Carlos Rosales, Hamal Marino, based on templates of other transmissions
+
+#ifndef TRANSMISSION_INTERFACE_ADAPTIVE_SYNERGY_TRANSMISSION_LOADER_H
+#define TRANSMISSION_INTERFACE_ADAPTIVE_SYNERGY_TRANSMISSION_LOADER_H
+
+// TinyXML
+#include <tinyxml.h>
+
+// ros_control
+#include <transmission_interface/transmission_loader.h>
+
+namespace transmission_interface
+{
+
+/**
+ * \brief Class for loading a Adaptive Synergy transmission instance from configuration data.
+ */
+class AdaptiveSynergyTransmissionLoader : public TransmissionLoader
+{
+public:
+  TransmissionPtr load(const TransmissionInfo& transmission_info);
+
+private:
+  static bool getActuatorConfig(const TransmissionInfo& transmission_info,
+                                std::vector<double>&    actuator_reduction);
+
+  static bool getJointConfig(const TransmissionInfo& transmission_info,
+                             std::vector<double>&    joint_reduction,
+                             std::vector<double>&    joint_elastic,
+                             std::vector<double>&    joint_offset);
+
+  // specific for SoftHand elastic joints
+  static ParseStatus getJointElastic(const TiXmlElement& parent_el,
+                                     const std::string&  joint_name,
+                                     const std::string&  transmission_name,
+                                     bool                required,
+                                     double&             elastic);
+};
+
+} // namespace
+
+#endif //header guard

--- a/gazebo_ros_soft_hand/include/adaptive_transmission/loader_utils.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/loader_utils.h
@@ -1,0 +1,59 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Daniel Pinyol
+
+#include <boost/scoped_ptr.hpp>
+#include <pluginlib/class_loader.h>
+#include <transmission_interface/simple_transmission.h>
+#include <transmission_interface/transmission_loader.h>
+
+using namespace transmission_interface;
+typedef TransmissionLoader::TransmissionPtr TransmissionPtr;
+
+
+struct TransmissionPluginLoader
+{
+  TransmissionPluginLoader()
+    :class_loader_("transmission_interface", "transmission_interface::TransmissionLoader")
+  {
+  }
+
+  boost::shared_ptr<TransmissionLoader> create(const std::string& type)
+  {
+
+    try
+    {
+      return class_loader_.createInstance(type);
+    }
+    catch(...) {return boost::shared_ptr<TransmissionLoader>();}
+  }
+
+private:
+  //must keep it alive because instance destroyers need it
+  pluginlib::ClassLoader<TransmissionLoader>  class_loader_;
+};

--- a/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/default_soft_hand_hw_sim.h
+++ b/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/default_soft_hand_hw_sim.h
@@ -190,7 +190,7 @@ protected:
 
   // adaptive transmission only, the simple transmission of the synergy joint
   // is not used so far, but it could be a way to model motor dynamics later
-  transmission_interface::AdaptiveSynergyTransmission* adaptive_trans_;
+  adaptive_transmission_interface::AdaptiveSynergyTransmission* adaptive_trans_;
 
   // transmission interfaces
   transmission_interface::JointToActuatorEffortInterface jnt_to_act_eff_;

--- a/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/default_soft_hand_hw_sim.h
+++ b/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/default_soft_hand_hw_sim.h
@@ -38,7 +38,7 @@
 /* Author: Dave Coleman, Johnathan Bohren
    Desc:   Hardware Interface for any simulated robot in Gazebo
 
-   Author: Carlos Rosales
+   Author: Carlos Rosales, Hamal Marino
    Desc: Not any simulated robot, this is the soft hand hardware interface for simulation
 */
 
@@ -54,15 +54,12 @@
 #include <joint_limits_interface/joint_limits_rosparam.h>
 #include <joint_limits_interface/joint_limits_urdf.h>
 
-// you need the forked version of ros_control to have this compact loading capabilites
-// and of course, the adaptive synergy transmission, and modifications on the
-// transmission propagation method
+// you need the forked version of ros_control to use this version of the SoftHand in simulation
 // git clone https://github.com/CentroEPiaggio/ros_control.git
 #include <transmission_interface/transmission_interface.h>
-#include <transmission_interface/adaptive_synergy_transmission.h>
 #include <transmission_interface/transmission_loader.h>
-#include <transmission_interface/read_file.h>
-#include <transmission_interface/loader_utils.h>
+#include <adaptive_transmission/adaptive_synergy_transmission.h>
+#include <adaptive_transmission/loader_utils.h>
 
 // Gazebo
 #include <gazebo/common/common.hh>

--- a/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/kinematic_ctrl_soft_hand_hw_sim.h
+++ b/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/kinematic_ctrl_soft_hand_hw_sim.h
@@ -163,7 +163,7 @@ protected:
 
   // adaptive transmission only, the simple transmission from the synergy joint
   // is not used so far, but it could be a way to model motor dynamics later
-  transmission_interface::AdaptiveSynergyTransmission* adaptive_trans_;  
+  adaptive_transmission_interface::AdaptiveSynergyTransmission* adaptive_trans_;  
 
   // transmission interfaces
   transmission_interface::JointToActuatorEffortInterface jnt_to_act_eff_;

--- a/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/kinematic_ctrl_soft_hand_hw_sim.h
+++ b/gazebo_ros_soft_hand/include/gazebo_ros_soft_hand/kinematic_ctrl_soft_hand_hw_sim.h
@@ -37,7 +37,7 @@
 /* Author: Dave Coleman, Johnathan Bohren
    Desc:   Hardware Interface for any simulated robot in Gazebo
 
-   Author: Carlos Rosales
+   Author: Carlos Rosales, Hamal Marino
    Desc: Not any simulated robot! This is the soft hand hardware interface for simulation
 */
 
@@ -53,15 +53,12 @@
 #include <joint_limits_interface/joint_limits_rosparam.h>
 #include <joint_limits_interface/joint_limits_urdf.h>
 
-// you need the forked version of ros_control to have this compact loading capabilites
-// and of course, the adaptive synergy transmission, and modifications on the
-// transmission propagation method
-// git clone 
+// you need the forked version of ros_control to use this version of the SoftHand in simulation
+// git clone https://github.com/CentroEPiaggio/ros_control.git
 #include <transmission_interface/transmission_interface.h>
-#include <transmission_interface/adaptive_synergy_transmission.h>
 #include <transmission_interface/transmission_loader.h>
-#include <transmission_interface/read_file.h>
-#include <transmission_interface/loader_utils.h>
+#include <adaptive_transmission/adaptive_synergy_transmission.h>
+#include <adaptive_transmission/loader_utils.h>
 
 // Gazebo
 #include <gazebo/common/common.hh>

--- a/gazebo_ros_soft_hand/package.xml
+++ b/gazebo_ros_soft_hand/package.xml
@@ -20,7 +20,8 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>kdl_conversions</build_depend>
   <build_depend>cmake_modules</build_depend>
-
+  <build_depend>hardware_interface</build_depend>
+  
   <run_depend>roscpp</run_depend> 
   <run_depend>gazebo_ros</run_depend> 
   <run_depend>control_toolbox</run_depend> 
@@ -30,6 +31,7 @@
   <run_depend>urdf</run_depend>
   <run_depend>orocos_kdl</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>hardware_interface</run_depend>
 
   <export>
     <gazebo_ros_soft_hand plugin="${prefix}/soft_hand_hw_sim_plugins.xml"/>

--- a/gazebo_ros_soft_hand/package.xml
+++ b/gazebo_ros_soft_hand/package.xml
@@ -36,5 +36,6 @@
   <export>
     <gazebo_ros_soft_hand plugin="${prefix}/soft_hand_hw_sim_plugins.xml"/>
     <gazebo_ros plugin_path="${prefix}/lib"/>
+    <transmission_interface plugin="${prefix}/adaptive_transmission_plugin.xml"/>
   </export>
 </package>

--- a/gazebo_ros_soft_hand/src/adaptive_synergy_transmission_loader.cpp
+++ b/gazebo_ros_soft_hand/src/adaptive_synergy_transmission_loader.cpp
@@ -1,0 +1,277 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2014, Research Center "E. Piaggio"
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// \author Adolfo Rodriguez Tsouroukdissian
+
+// \author Carlos Rosales, Hamal Marino, based on templates of other transmissions
+
+// ROS
+#include <ros/console.h>
+
+// Pluginlib
+#include <pluginlib/class_list_macros.h>
+
+// ros_control
+#include <hardware_interface/internal/demangle_symbol.h>
+#include <adaptive_transmission/adaptive_synergy_transmission.h>
+#include <adaptive_transmission/adaptive_synergy_transmission_loader.h>
+#include <boost/lexical_cast.hpp>
+
+namespace transmission_interface
+{
+
+AdaptiveSynergyTransmissionLoader::TransmissionPtr
+AdaptiveSynergyTransmissionLoader::load(const TransmissionInfo& transmission_info)
+{
+  // Transmission should contain only one actuator/joint
+  if (!checkActuatorDimension(transmission_info, 1)) {return TransmissionPtr();}
+  if (!checkJointDimension(transmission_info,    19)) {return TransmissionPtr();}
+
+  // Get actuator and joint configuration sorted by role: [actuator1] and [joint1,..., joint19]
+  std::vector<double> act_reduction;
+  const bool act_config_ok = getActuatorConfig(transmission_info, act_reduction);
+  if (!act_config_ok) {return TransmissionPtr();}
+
+  std::vector<double> jnt_reduction;
+  std::vector<double> jnt_elastic;
+  std::vector<double> jnt_offset;
+  const bool jnt_config_ok = getJointConfig(transmission_info,
+                                            jnt_reduction,
+                                            jnt_elastic,
+                                            jnt_offset);
+
+  if (!jnt_config_ok) {return TransmissionPtr();}
+
+  // Transmission instance
+  try
+  {
+    TransmissionPtr transmission(new AdaptiveSynergyTransmission(act_reduction,
+                                                              jnt_reduction,
+                                                              jnt_elastic,
+                                                              jnt_offset));
+    return transmission;
+  }
+  catch(const TransmissionInterfaceException& ex)
+  {
+    using hardware_interface::internal::demangledTypeName;
+    ROS_ERROR_STREAM_NAMED("parser", "Failed to construct transmission '" << transmission_info.name_ << "' of type '" <<
+                           demangledTypeName<AdaptiveSynergyTransmission>()<< "'. " << ex.what());
+    return TransmissionPtr();
+  }
+}
+
+bool AdaptiveSynergyTransmissionLoader::getActuatorConfig(const TransmissionInfo& transmission_info,
+                                                       std::vector<double>&    actuator_reduction)
+{
+  const std::string ACTUATOR1_ROLE = "actuator1";
+  
+  std::vector<TiXmlElement> act_elements(1,"");
+  std::vector<std::string>  act_names(1);
+  std::vector<std::string>  act_roles(1);
+
+  for (unsigned int i = 0; i < 1; ++i)
+  {
+    // Actuator name
+    act_names[i] = transmission_info.actuators_[i].name_;
+
+    // Actuator xml element
+    act_elements[i] = loadXmlElement(transmission_info.actuators_[i].xml_element_);
+
+    // Populate role string
+    std::string& act_role = act_roles[i];
+    const ParseStatus act_role_status = getActuatorRole(act_elements[i],
+                                                        act_names[i],
+                                                        transmission_info.name_,
+                                                        false, // Required
+                                                        act_role);
+    if (act_role_status != SUCCESS) {return false;}
+
+    // Validate role string
+    if (ACTUATOR1_ROLE != act_role)
+    {
+      ROS_ERROR_STREAM_NAMED("parser", "Actuator '" << act_names[i] << "' of transmission '" << transmission_info.name_ <<
+                             "' does not specify a valid <role> element. Got '" << act_role << "', expected '" <<
+                             ACTUATOR1_ROLE << "'.");
+      return false;
+    }
+  }
+
+  // Parse required mechanical reductions
+  actuator_reduction.resize(1);
+
+  const ParseStatus reduction_status = getActuatorReduction(act_elements[0],
+                                                              act_names[0],
+                                                              transmission_info.name_,
+                                                              true, // Required
+                                                              actuator_reduction[0]);
+  if (reduction_status != SUCCESS) {return false;}
+
+  return true;
+}
+
+bool AdaptiveSynergyTransmissionLoader::getJointConfig(const TransmissionInfo& transmission_info,
+                                                    std::vector<double>&    joint_reduction,
+                                                    std::vector<double>&    joint_elastic,
+                                                    std::vector<double>&    joint_offset)
+{
+  const std::string JOINT1_ROLE = "joint1";
+  const std::string JOINT2_ROLE = "joint2";
+  const std::string JOINT3_ROLE = "joint3";
+  const std::string JOINT4_ROLE = "joint4";
+  const std::string JOINT5_ROLE = "joint5";
+  const std::string JOINT6_ROLE = "joint6";
+  const std::string JOINT7_ROLE = "joint7";
+  const std::string JOINT8_ROLE = "joint8";
+  const std::string JOINT9_ROLE = "joint9";
+  const std::string JOINT10_ROLE = "joint10";
+  const std::string JOINT11_ROLE = "joint11";
+  const std::string JOINT12_ROLE = "joint12";
+  const std::string JOINT13_ROLE = "joint13";
+  const std::string JOINT14_ROLE = "joint14";
+  const std::string JOINT15_ROLE = "joint15";
+  const std::string JOINT16_ROLE = "joint16";
+  const std::string JOINT17_ROLE = "joint17";
+  const std::string JOINT18_ROLE = "joint18";
+  const std::string JOINT19_ROLE = "joint19";
+    
+  std::vector<TiXmlElement> jnt_elements(19,"");
+  std::vector<std::string>  jnt_names(19);
+  std::vector<std::string>  jnt_roles(19);
+
+  for (unsigned int i = 0; i < 19; ++i)
+  {
+    // Joint name
+    jnt_names[i] = transmission_info.joints_[i].name_;
+
+    // Joint xml element
+    jnt_elements[i] = loadXmlElement(transmission_info.joints_[i].xml_element_);
+
+    // Populate role string
+    std::string& jnt_role = jnt_roles[i];
+    const ParseStatus jnt_role_status = getJointRole(jnt_elements[i],
+                                                     jnt_names[i],
+                                                     transmission_info.name_,
+                                                     true, // Required
+                                                     jnt_role);
+    if (jnt_role_status != SUCCESS) {return false;}
+
+    // Validate role string
+    if (JOINT1_ROLE != jnt_role && JOINT2_ROLE != jnt_role && JOINT3_ROLE != jnt_role && JOINT4_ROLE != jnt_role
+      && JOINT5_ROLE != jnt_role && JOINT6_ROLE != jnt_role && JOINT7_ROLE != jnt_role && JOINT8_ROLE != jnt_role
+      && JOINT9_ROLE != jnt_role && JOINT10_ROLE != jnt_role && JOINT11_ROLE != jnt_role && JOINT12_ROLE != jnt_role 
+      && JOINT13_ROLE != jnt_role && JOINT14_ROLE != jnt_role && JOINT15_ROLE != jnt_role && JOINT16_ROLE != jnt_role
+      && JOINT17_ROLE != jnt_role && JOINT18_ROLE != jnt_role && JOINT19_ROLE != jnt_role)
+    {
+      ROS_ERROR_STREAM_NAMED("parser", "Joint '" << jnt_names[i] << "' of transmission '" << transmission_info.name_ <<
+                             "' does not specify a valid <role> element. Got '" << jnt_role << "', expected '" <<
+                             JOINT1_ROLE << "' to '" << JOINT19_ROLE << "'.");
+      return false;
+    }
+  }
+
+  // TODO: check that roles are different
+  // Roles must be different
+/*  if (jnt_roles[0] == jnt_roles[1])
+  {
+    ROS_ERROR_STREAM_NAMED("parser", "Joints '" << jnt_names[0] << "' and '" << jnt_names[1] <<
+                           "' of transmission '" << transmission_info.name_ <<
+                           "' must have different roles. Both specify '" << jnt_roles[0] << "'.");
+    return false;
+  }*/
+
+  // Joint configuration
+  joint_reduction.resize(19, 1.0);
+  joint_elastic.resize(19, 1.0);
+  joint_offset.resize(19, 0.0);
+  for (unsigned int i = 0; i < 19; ++i)
+  {
+
+    // Parse optional mechanical reductions. Even though it's optional --and to avoid surprises-- we fail if the element
+    // is specified but is of the wrong type
+    const ParseStatus reduction_status = getJointReduction(jnt_elements[i],
+                                                           jnt_names[i],
+                                                           transmission_info.name_,
+                                                           false, // Optional
+                                                           joint_reduction[i]);
+    if (reduction_status == BAD_TYPE) {return false;}
+
+    // Parse optional mechanical elasticities. Even though it's optional --and to avoid surprises-- we fail if the element
+    // is specified but is of the wrong type
+    const ParseStatus elastic_status = getJointElastic(jnt_elements[i],
+                                                           jnt_names[i],
+                                                           transmission_info.name_,
+                                                           false, // Optional
+                                                           joint_elastic[i]);
+    if (elastic_status == BAD_TYPE) {return false;}
+
+    // Parse optional joint offset. Even though it's optional --and to avoid surprises-- we fail if the element is
+    // specified but is of the wrong type
+    const ParseStatus offset_status = getJointOffset(jnt_elements[i],
+                                                     jnt_names[i],
+                                                     transmission_info.name_,
+                                                     false, // Optional
+                                                     joint_offset[i]);
+    if (offset_status == BAD_TYPE) {return false;}
+  }
+
+  return true;
+}
+
+TransmissionLoader::ParseStatus AdaptiveSynergyTransmissionLoader::getJointElastic(const TiXmlElement& parent_el, const std::string& joint_name, const std::string& transmission_name, bool required, double& elastic)
+{
+    // Get XML element
+    const TiXmlElement* elastic_el = parent_el.FirstChildElement("mechanicalElasticity");
+    if(!elastic_el)
+    {
+        if (required)
+        {
+            ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
+            "' does not specify the required <mechanicalElasticity> element.");
+        }
+        else
+        {
+            ROS_DEBUG_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
+            "' does not specify the optional <mechanicalElasticity> element.");
+        }
+        return NO_DATA;
+    }
+    // Cast to number
+    try {elastic = boost::lexical_cast<double>(elastic_el->GetText());}
+    catch (const boost::bad_lexical_cast&)
+    {
+        ROS_ERROR_STREAM_NAMED("parser", "Joint '" << joint_name << "' of transmission '" << transmission_name <<
+        "' specifies the <mechanicalElasticity> element, but is not a number.");
+        return BAD_TYPE;
+    }
+    return SUCCESS;
+}
+
+} // namespace
+
+PLUGINLIB_EXPORT_CLASS(transmission_interface::AdaptiveSynergyTransmissionLoader,
+                       transmission_interface::TransmissionLoader)

--- a/gazebo_ros_soft_hand/src/adaptive_synergy_transmission_loader.cpp
+++ b/gazebo_ros_soft_hand/src/adaptive_synergy_transmission_loader.cpp
@@ -42,8 +42,10 @@
 #include <adaptive_transmission/adaptive_synergy_transmission_loader.h>
 #include <boost/lexical_cast.hpp>
 
-namespace transmission_interface
+namespace adaptive_transmission_interface
 {
+
+using namespace transmission_interface;
 
 AdaptiveSynergyTransmissionLoader::TransmissionPtr
 AdaptiveSynergyTransmissionLoader::load(const TransmissionInfo& transmission_info)
@@ -273,5 +275,5 @@ TransmissionLoader::ParseStatus AdaptiveSynergyTransmissionLoader::getJointElast
 
 } // namespace
 
-PLUGINLIB_EXPORT_CLASS(transmission_interface::AdaptiveSynergyTransmissionLoader,
+PLUGINLIB_EXPORT_CLASS(adaptive_transmission_interface::AdaptiveSynergyTransmissionLoader,
                        transmission_interface::TransmissionLoader)

--- a/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
+++ b/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
@@ -1,5 +1,5 @@
 /* 
-   Author: Carlos Rosales
+   Author: Carlos Rosales, Hamal Marino
    Desc: Not any simulated robot, this is the soft hand hardware interface for simulation.
    Based on the Hardware Interface for any simulated robot in Gazebo by
    Dave Coleman, Johnathan Bohren
@@ -8,6 +8,7 @@
 */
 
 #include <gazebo_ros_soft_hand/default_soft_hand_hw_sim.h>
+#include <adaptive_transmission/adaptive_synergy_transmission_loader.h>
 
 namespace
 {
@@ -64,9 +65,11 @@ bool DefaultSoftHandHWSim::initSim(
   /////////////////////////////////
   ROS_INFO("1. Load the adaptive transmission.");
 
-  TransmissionPluginLoader loader;
-  boost::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader = loader.create(adaptive_trans_info.type_);
-
+  // this is specific, and uses a local library to load the adaptive transmission - instead of the more generic:
+  // // TransmissionPluginLoader loader;
+  // // boost::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader = loader.create(adaptive_trans_info.type_);
+  boost::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader = boost::shared_ptr<transmission_interface::TransmissionLoader>(new transmission_interface::AdaptiveSynergyTransmissionLoader());
+  
   assert(0 != transmission_loader);
 
   TransmissionPtr transmission;

--- a/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
+++ b/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
@@ -77,9 +77,9 @@ bool DefaultSoftHandHWSim::initSim(
   
   assert(0 != transmission);
 
-  transmission_interface::AdaptiveSynergyTransmission* adaptive_trans = dynamic_cast<transmission_interface::AdaptiveSynergyTransmission*>(transmission.get());
+  adaptive_transmission_interface::AdaptiveSynergyTransmission* adaptive_trans = dynamic_cast<adaptive_transmission_interface::AdaptiveSynergyTransmission*>(transmission.get());
 
-  adaptive_trans_ = new transmission_interface::AdaptiveSynergyTransmission(adaptive_trans->getActuatorReduction(),
+  adaptive_trans_ = new adaptive_transmission_interface::AdaptiveSynergyTransmission(adaptive_trans->getActuatorReduction(),
                                                                             adaptive_trans->getJointReduction(),
                                                                             adaptive_trans->getJointElastic(),
                                                                             adaptive_trans->getJointOffset());

--- a/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
+++ b/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
@@ -8,7 +8,6 @@
 */
 
 #include <gazebo_ros_soft_hand/default_soft_hand_hw_sim.h>
-#include <adaptive_transmission/adaptive_synergy_transmission_loader.h>
 
 namespace
 {
@@ -66,9 +65,8 @@ bool DefaultSoftHandHWSim::initSim(
   ROS_INFO("1. Load the adaptive transmission.");
 
   // this is specific, and uses a local library to load the adaptive transmission - instead of the more generic:
-  // // TransmissionPluginLoader loader;
-  // // boost::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader = loader.create(adaptive_trans_info.type_);
-  boost::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader = boost::shared_ptr<transmission_interface::TransmissionLoader>(new transmission_interface::AdaptiveSynergyTransmissionLoader());
+  TransmissionPluginLoader loader;
+  boost::shared_ptr<transmission_interface::TransmissionLoader> transmission_loader = loader.create(adaptive_trans_info.type_);
   
   assert(0 != transmission_loader);
 

--- a/gazebo_ros_soft_hand/src/gazebo_ros_soft_hand_plugin.cpp
+++ b/gazebo_ros_soft_hand/src/gazebo_ros_soft_hand_plugin.cpp
@@ -265,7 +265,7 @@ bool GazeboRosSoftHandPlugin::parseTransmissionsFromURDF(const std::string& urdf
   std::vector<transmission_interface::TransmissionInfo>::iterator it = transmissions_.begin();
   for(; it != transmissions_.end(); ) 
   {
-    if (robot_namespace_.compare(it->robot_namespace_) != 0)
+    if (it->name_.compare(0,robot_namespace_.length(),robot_namespace_) != 0 )
     {
       ROS_WARN_STREAM_NAMED("gazebo_ros_soft_hand", "gazebo_ros_soft_hand plugin deleted transmission "
         << it->name_

--- a/gazebo_ros_soft_hand/src/kinematic_ctrl_soft_hand_hw_sim.cpp
+++ b/gazebo_ros_soft_hand/src/kinematic_ctrl_soft_hand_hw_sim.cpp
@@ -109,7 +109,7 @@ bool KinematicCtrlSoftHandHWSim::initSim(
   assert(0 != transmission);
 
   // Validate transmission
-  adaptive_trans_ = dynamic_cast<transmission_interface::AdaptiveSynergyTransmission*>(transmission.get());
+  adaptive_trans_ = dynamic_cast<adaptive_transmission_interface::AdaptiveSynergyTransmission*>(transmission.get());
 
   assert(0 != adaptive_trans_);
 

--- a/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_loader_test.cpp
+++ b/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_loader_test.cpp
@@ -1,0 +1,245 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2014, Research Center "E. Piaggio"
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// \author Adolfo Rodriguez Tsouroukdissian
+
+// \author Carlos Rosales, based on templates of other transmissions
+
+#include <string>
+#include <boost/foreach.hpp>
+#include <gtest/gtest.h>
+#include <pluginlib/class_loader.h>
+#include <adaptive_transmission/adaptive_synergy_transmission.h>
+#include <transmission_interface/transmission_loader.h>
+#include "./read_file.h"
+#include <adaptive_transmission/loader_utils.h>
+
+
+
+TEST(AdaptiveSynergyTransmissionLoaderTest, FullSpec)
+{
+
+// Parse transmission info
+  std::vector<TransmissionInfo> infos = parseUrdf("test/urdf/adaptive_synergy_transmission_loader_full.urdf");
+  ASSERT_EQ(1, infos.size());
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  boost::shared_ptr<TransmissionLoader> transmission_loader = loader.create(infos.front().type_);
+  
+  ASSERT_TRUE(0 != transmission_loader);
+  
+  TransmissionPtr transmission;
+  const TransmissionInfo& info = infos.front();
+  
+  transmission = transmission_loader->load(info);
+  
+  ASSERT_TRUE(0 != transmission);
+
+  // Validate transmission
+  AdaptiveSynergyTransmission* adaptive_synergy_transmission = dynamic_cast<AdaptiveSynergyTransmission*>(transmission.get());
+  ASSERT_TRUE(0 != adaptive_synergy_transmission);
+
+  const std::vector<double>& actuator_reduction = adaptive_synergy_transmission->getActuatorReduction();
+  EXPECT_EQ( 30.0, actuator_reduction[0]);
+
+  const std::vector<double>& joint_reduction = adaptive_synergy_transmission->getJointReduction();
+  EXPECT_EQ( 2.0, joint_reduction[0]);
+  EXPECT_EQ( 2.0, joint_reduction[1]);
+  EXPECT_EQ( 2.0, joint_reduction[2]);
+  EXPECT_EQ( 2.0, joint_reduction[3]);
+  EXPECT_EQ( 2.0, joint_reduction[4]);
+  EXPECT_EQ( 2.0, joint_reduction[5]);
+  EXPECT_EQ( 2.0, joint_reduction[6]);
+  EXPECT_EQ( 2.0, joint_reduction[7]);
+  EXPECT_EQ( 2.0, joint_reduction[8]);
+  EXPECT_EQ( 2.0, joint_reduction[9]);
+  EXPECT_EQ( 2.0, joint_reduction[10]);
+  EXPECT_EQ( 2.0, joint_reduction[11]);
+  EXPECT_EQ( 2.0, joint_reduction[12]);
+  EXPECT_EQ( 2.0, joint_reduction[13]);
+  EXPECT_EQ( 2.0, joint_reduction[14]);
+  EXPECT_EQ( 2.0, joint_reduction[15]);
+  EXPECT_EQ( 2.0, joint_reduction[16]);
+  EXPECT_EQ( 2.0, joint_reduction[17]);
+  EXPECT_EQ( 2.0, joint_reduction[18]);
+
+  const std::vector<double>& joint_elastic = adaptive_synergy_transmission->getJointElastic();
+  EXPECT_EQ( 3.0, joint_elastic[0]);
+  EXPECT_EQ( 3.0, joint_elastic[1]);
+  EXPECT_EQ( 3.0, joint_elastic[2]);
+  EXPECT_EQ( 3.0, joint_elastic[3]);
+  EXPECT_EQ( 3.0, joint_elastic[4]);
+  EXPECT_EQ( 3.0, joint_elastic[5]);
+  EXPECT_EQ( 3.0, joint_elastic[6]);
+  EXPECT_EQ( 3.0, joint_elastic[7]);
+  EXPECT_EQ( 3.0, joint_elastic[8]);
+  EXPECT_EQ( 3.0, joint_elastic[9]);
+  EXPECT_EQ( 3.0, joint_elastic[10]);
+  EXPECT_EQ( 3.0, joint_elastic[11]);
+  EXPECT_EQ( 3.0, joint_elastic[12]);
+  EXPECT_EQ( 3.0, joint_elastic[13]);
+  EXPECT_EQ( 3.0, joint_elastic[14]);
+  EXPECT_EQ( 3.0, joint_elastic[15]);
+  EXPECT_EQ( 3.0, joint_elastic[16]);
+  EXPECT_EQ( 3.0, joint_elastic[17]);
+  EXPECT_EQ( 3.0, joint_elastic[18]);
+
+  const std::vector<double>& joint_offset = adaptive_synergy_transmission->getJointOffset();
+  EXPECT_EQ( -0.5, joint_offset[0]);
+  EXPECT_EQ( -0.5, joint_offset[1]);
+  EXPECT_EQ( -0.5, joint_offset[2]);
+  EXPECT_EQ( -0.5, joint_offset[3]);
+  EXPECT_EQ( -0.5, joint_offset[4]);
+  EXPECT_EQ( -0.5, joint_offset[5]);
+  EXPECT_EQ( -0.5, joint_offset[6]);
+  EXPECT_EQ( -0.5, joint_offset[7]);
+  EXPECT_EQ( -0.5, joint_offset[8]);
+  EXPECT_EQ( -0.5, joint_offset[9]);
+  EXPECT_EQ( -0.5, joint_offset[10]);
+  EXPECT_EQ( -0.5, joint_offset[11]);
+  EXPECT_EQ( -0.5, joint_offset[12]);
+  EXPECT_EQ( -0.5, joint_offset[13]);
+  EXPECT_EQ( -0.5, joint_offset[14]);
+  EXPECT_EQ( -0.5, joint_offset[15]);
+  EXPECT_EQ( -0.5, joint_offset[16]);
+  EXPECT_EQ( -0.5, joint_offset[17]);
+  EXPECT_EQ( -0.5, joint_offset[18]);
+}
+
+
+TEST(AdaptiveSynergyTransmissionLoaderTest, MinimalSpec)
+{
+  // Parse transmission info
+  std::vector<TransmissionInfo> infos = parseUrdf("test/urdf/adaptive_synergy_transmission_loader_minimal.urdf");
+  ASSERT_EQ(1, infos.size());
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  boost::shared_ptr<TransmissionLoader> transmission_loader = loader.create(infos.front().type_);
+  ASSERT_TRUE(0 != transmission_loader);
+
+  TransmissionPtr transmission;
+  const TransmissionInfo& info = infos.front();
+  transmission = transmission_loader->load(info);
+  ASSERT_TRUE(0 != transmission);
+
+  // Validate transmission
+  AdaptiveSynergyTransmission* adaptive_synergy_transmission = dynamic_cast<AdaptiveSynergyTransmission*>(transmission.get());
+
+  const std::vector<double>& actuator_reduction = adaptive_synergy_transmission->getActuatorReduction();
+  EXPECT_EQ( 30.0, actuator_reduction[0]);
+  
+  const std::vector<double>& joint_reduction = adaptive_synergy_transmission->getJointReduction();
+  EXPECT_EQ( 1.0, joint_reduction[0]);
+  EXPECT_EQ( 1.0, joint_reduction[1]);
+  EXPECT_EQ( 1.0, joint_reduction[2]);
+  EXPECT_EQ( 1.0, joint_reduction[3]);
+  EXPECT_EQ( 1.0, joint_reduction[4]);
+  EXPECT_EQ( 1.0, joint_reduction[5]);
+  EXPECT_EQ( 1.0, joint_reduction[6]);
+  EXPECT_EQ( 1.0, joint_reduction[7]);
+  EXPECT_EQ( 1.0, joint_reduction[8]);
+  EXPECT_EQ( 1.0, joint_reduction[9]);
+  EXPECT_EQ( 1.0, joint_reduction[10]);
+  EXPECT_EQ( 1.0, joint_reduction[11]);
+  EXPECT_EQ( 1.0, joint_reduction[12]);
+  EXPECT_EQ( 1.0, joint_reduction[13]);
+  EXPECT_EQ( 1.0, joint_reduction[14]);
+  EXPECT_EQ( 1.0, joint_reduction[15]);
+  EXPECT_EQ( 1.0, joint_reduction[16]);
+  EXPECT_EQ( 1.0, joint_reduction[17]);
+  EXPECT_EQ( 1.0, joint_reduction[18]);
+
+ const std::vector<double>& joint_elastic = adaptive_synergy_transmission->getJointElastic();
+  EXPECT_EQ( 1.0, joint_elastic[0]);
+  EXPECT_EQ( 1.0, joint_elastic[1]);
+  EXPECT_EQ( 1.0, joint_elastic[2]);
+  EXPECT_EQ( 1.0, joint_elastic[3]);
+  EXPECT_EQ( 1.0, joint_elastic[4]);
+  EXPECT_EQ( 1.0, joint_elastic[5]);
+  EXPECT_EQ( 1.0, joint_elastic[6]);
+  EXPECT_EQ( 1.0, joint_elastic[7]);
+  EXPECT_EQ( 1.0, joint_elastic[8]);
+  EXPECT_EQ( 1.0, joint_elastic[9]);
+  EXPECT_EQ( 1.0, joint_elastic[10]);
+  EXPECT_EQ( 1.0, joint_elastic[11]);
+  EXPECT_EQ( 1.0, joint_elastic[12]);
+  EXPECT_EQ( 1.0, joint_elastic[13]);
+  EXPECT_EQ( 1.0, joint_elastic[14]);
+  EXPECT_EQ( 1.0, joint_elastic[15]);
+  EXPECT_EQ( 1.0, joint_elastic[16]);
+  EXPECT_EQ( 1.0, joint_elastic[17]);
+  EXPECT_EQ( 1.0, joint_elastic[18]);
+
+  const std::vector<double>& joint_offset = adaptive_synergy_transmission->getJointOffset();
+  EXPECT_EQ( 0.0, joint_offset[0]);
+  EXPECT_EQ( 0.0, joint_offset[1]);
+  EXPECT_EQ( 0.0, joint_offset[2]);
+  EXPECT_EQ( 0.0, joint_offset[3]);
+  EXPECT_EQ( 0.0, joint_offset[4]);
+  EXPECT_EQ( 0.0, joint_offset[5]);
+  EXPECT_EQ( 0.0, joint_offset[6]);
+  EXPECT_EQ( 0.0, joint_offset[7]);
+  EXPECT_EQ( 0.0, joint_offset[8]);
+  EXPECT_EQ( 0.0, joint_offset[9]);
+  EXPECT_EQ( 0.0, joint_offset[10]);
+  EXPECT_EQ( 0.0, joint_offset[11]);
+  EXPECT_EQ( 0.0, joint_offset[12]);
+  EXPECT_EQ( 0.0, joint_offset[13]);
+  EXPECT_EQ( 0.0, joint_offset[14]);
+  EXPECT_EQ( 0.0, joint_offset[15]);
+  EXPECT_EQ( 0.0, joint_offset[16]);
+  EXPECT_EQ( 0.0, joint_offset[17]);
+  EXPECT_EQ( 0.0, joint_offset[18]);
+}
+
+TEST(AdaptiveSynergyTransmissionLoaderTest, InvalidSpec)
+{
+  // Parse transmission info
+  std::vector<TransmissionInfo> infos = parseUrdf("test/urdf/adaptive_synergy_transmission_loader_invalid.urdf");
+  ASSERT_EQ(12, infos.size());
+
+  // Transmission loader
+  TransmissionPluginLoader loader;
+  boost::shared_ptr<TransmissionLoader> transmission_loader = loader.create(infos.front().type_);
+  ASSERT_TRUE(0 != transmission_loader);
+
+  BOOST_FOREACH(const TransmissionInfo& info, infos)
+  {
+    TransmissionPtr transmission;
+    transmission = transmission_loader->load(info);
+    ASSERT_TRUE(0 == transmission);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_test.cpp
+++ b/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_test.cpp
@@ -1,0 +1,692 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2014, Research Center "E. Piaggio"
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// \author Adolfo Rodriguez Tsouroukdissian
+
+// \author Carlos Rosales, based on templates of other transmissions
+
+
+#include <gtest/gtest.h>
+
+#include <adaptive_transmission/adaptive_synergy_transmission.h>
+#include "./random_generator_utils.h"
+
+using namespace transmission_interface;
+using std::vector;
+
+// Floating-point value comparison threshold
+const double EPS = 1e-6;
+
+TEST(PreconditionsTest, ExceptionThrowing)
+{
+  vector<double> act_reduction_good(1, 1.0);
+  vector<double> act_reduction_bad1(1, 0.0);
+  vector<double> act_reduction_bad2(2, 1.0);
+
+  vector<double> joint_reduction_bad(19, 0.0);
+  vector<double> joint_reduction_good(19, 1.0);
+  vector<double> joint_elastic_bad(19, 0.0);
+  vector<double> joint_elastic_good(19, 1.0);
+  vector<double> joint_offset_good(19, 1.0);
+
+  // Invalid instance creation: Transmission cannot have zero reduction
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_bad1, joint_reduction_good, joint_elastic_good), TransmissionInterfaceException);
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_bad2, joint_reduction_good, joint_elastic_good), TransmissionInterfaceException);
+  
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_good, joint_reduction_bad, joint_elastic_good), TransmissionInterfaceException);
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_good, joint_reduction_good, joint_elastic_bad), TransmissionInterfaceException);
+  
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_bad1, joint_reduction_good, joint_elastic_good, joint_offset_good), TransmissionInterfaceException);
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_bad2, joint_reduction_good, joint_elastic_good, joint_offset_good), TransmissionInterfaceException);
+  
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_good, joint_reduction_bad, joint_elastic_good, joint_offset_good), TransmissionInterfaceException);
+  EXPECT_THROW(AdaptiveSynergyTransmission(act_reduction_good, joint_reduction_good, joint_elastic_bad, joint_offset_good), TransmissionInterfaceException);
+
+  // Valid instance creation
+  EXPECT_NO_THROW(AdaptiveSynergyTransmission(act_reduction_good, joint_reduction_good, joint_elastic_good));
+  EXPECT_NO_THROW(AdaptiveSynergyTransmission(act_reduction_good, joint_reduction_good, joint_elastic_good, joint_offset_good));
+}
+/*
+#ifndef NDEBUG // NOTE: This test validates assertion triggering, hence only gets compiled in debug mode
+TEST(PreconditionsTest, AssertionTriggering)
+{
+  // Create input/output transmission data
+  double a_val1 = 0.0, a_val2 = 0.0;
+  double j_val1 = 0.0, j_val2 = 0.0;
+
+  vector<double*> a_good_vec;
+  a_good_vec.push_back(&a_val1);
+  a_good_vec.push_back(&a_val2);
+
+  vector<double*> j_good_vec;
+  j_good_vec.push_back(&j_val1);
+  j_good_vec.push_back(&j_val2);
+
+  ActuatorData a_good_data;
+  a_good_data.position = a_good_vec;
+  a_good_data.velocity = a_good_vec;
+  a_good_data.effort   = a_good_vec;
+
+  JointData j_good_data;
+  j_good_data.position = j_good_vec;
+  j_good_data.velocity = j_good_vec;
+  j_good_data.effort   = j_good_vec;
+
+  ActuatorData a_bad_data;
+  a_bad_data.position = vector<double*>(2);
+  a_bad_data.velocity = vector<double*>(2);
+  a_bad_data.effort   = vector<double*>(2);
+
+  JointData j_bad_data;
+  j_bad_data.position = vector<double*>(2);
+  j_bad_data.velocity = vector<double*>(2);
+  j_bad_data.effort   = vector<double*>(2);
+
+  ActuatorData a_bad_size;
+  JointData    j_bad_size;
+
+  // Transmission instance
+  AdaptiveSynergyTransmission trans(vector<double>(2, 1.0),
+                                   vector<double>(2, 1.0));
+
+  // Data with invalid pointers should trigger an assertion
+  EXPECT_DEATH(trans.actuatorToJointEffort(a_bad_data,  j_bad_data),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointEffort(a_good_data, j_bad_data),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointEffort(a_bad_data,  j_good_data), ".*");
+
+  EXPECT_DEATH(trans.actuatorToJointVelocity(a_bad_data,  j_bad_data),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointVelocity(a_good_data, j_bad_data),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointVelocity(a_bad_data,  j_good_data), ".*");
+
+  EXPECT_DEATH(trans.actuatorToJointPosition(a_bad_data,  j_bad_data),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointPosition(a_good_data, j_bad_data),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointPosition(a_bad_data,  j_good_data), ".*");
+
+  EXPECT_DEATH(trans.jointToActuatorEffort(j_bad_data,  a_bad_data),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorEffort(j_good_data, a_bad_data),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorEffort(j_bad_data,  a_good_data), ".*");
+
+  EXPECT_DEATH(trans.jointToActuatorVelocity(j_bad_data,  a_bad_data),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorVelocity(j_good_data, a_bad_data),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorVelocity(j_bad_data,  a_good_data), ".*");
+
+  EXPECT_DEATH(trans.jointToActuatorPosition(j_bad_data,  a_bad_data),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorPosition(j_good_data, a_bad_data),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorPosition(j_bad_data,  a_good_data), ".*");
+
+  // Wrong parameter sizes should trigger an assertion
+  EXPECT_DEATH(trans.actuatorToJointEffort(a_bad_size,  j_bad_size),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointEffort(a_good_data, j_bad_size),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointEffort(a_bad_size,  j_good_data), ".*");
+
+  EXPECT_DEATH(trans.actuatorToJointVelocity(a_bad_size,  j_bad_size),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointVelocity(a_good_data, j_bad_size),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointVelocity(a_bad_size,  j_good_data), ".*");
+
+  EXPECT_DEATH(trans.actuatorToJointPosition(a_bad_size,  j_bad_size),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointPosition(a_good_data, j_bad_size),  ".*");
+  EXPECT_DEATH(trans.actuatorToJointPosition(a_bad_size,  j_good_data), ".*");
+
+  EXPECT_DEATH(trans.jointToActuatorEffort(j_bad_size,  a_bad_size),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorEffort(j_good_data, a_bad_size),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorEffort(j_bad_size,  a_good_data), ".*");
+
+  EXPECT_DEATH(trans.jointToActuatorVelocity(j_bad_size,  a_bad_size),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorVelocity(j_good_data, a_bad_size),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorVelocity(j_bad_size,  a_good_data), ".*");
+
+  EXPECT_DEATH(trans.jointToActuatorPosition(j_bad_size,  a_bad_size),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorPosition(j_good_data, a_bad_size),  ".*");
+  EXPECT_DEATH(trans.jointToActuatorPosition(j_bad_size,  a_good_data), ".*");
+}
+#endif // NDEBUG
+*/
+
+
+TEST(PreconditionsTest, AccessorValidation)
+{
+  std::vector<double> act_reduction(1);
+  act_reduction[0] =  10.0;
+
+  std::vector<double> jnt_reduction(19);
+  jnt_reduction[0] =  4.0;
+  jnt_reduction[1] = -4.0;
+  jnt_reduction[2] =  4.0;
+  jnt_reduction[3] = -4.0;
+  jnt_reduction[4] =  4.0;
+  jnt_reduction[5] = -4.0;
+  jnt_reduction[6] =  4.0;
+  jnt_reduction[7] = -4.0;
+  jnt_reduction[8] =  4.0;
+  jnt_reduction[9] = -4.0;
+  jnt_reduction[10] =  4.0;
+  jnt_reduction[11] = -4.0;
+  jnt_reduction[12] =  4.0;
+  jnt_reduction[13] = -4.0;
+  jnt_reduction[14] =  4.0;
+  jnt_reduction[15] = -4.0;
+  jnt_reduction[16] =  4.0;
+  jnt_reduction[17] = -4.0;
+  jnt_reduction[18] =  4.0;
+
+  std::vector<double> jnt_elastic(19);
+  jnt_elastic[0] =  5.0;
+  jnt_elastic[1] = -5.0;
+  jnt_elastic[2] =  5.0;
+  jnt_elastic[3] = -5.0;
+  jnt_elastic[4] =  5.0;
+  jnt_elastic[5] = -5.0;
+  jnt_elastic[6] =  5.0;
+  jnt_elastic[7] = -5.0;
+  jnt_elastic[8] =  5.0;
+  jnt_elastic[9] = -5.0;
+  jnt_elastic[10] =  5.0;
+  jnt_elastic[11] = -5.0;
+  jnt_elastic[12] =  5.0;
+  jnt_elastic[13] = -5.0;
+  jnt_elastic[14] =  5.0;
+  jnt_elastic[15] = -5.0;
+  jnt_elastic[16] =  5.0;
+  jnt_elastic[17] = -5.0;
+  jnt_elastic[18] =  5.0;
+
+  std::vector<double> jnt_offset(19);
+  jnt_offset[0] =  1.0;
+  jnt_offset[1] = -1.0;
+  jnt_offset[2] =  1.0;
+  jnt_offset[3] = -1.0;
+  jnt_offset[4] =  1.0;
+  jnt_offset[5] = -1.0;
+  jnt_offset[6] =  1.0;
+  jnt_offset[7] = -1.0;
+  jnt_offset[8] =  1.0;
+  jnt_offset[9] = -1.0;
+  jnt_offset[10] =  1.0;
+  jnt_offset[11] = -1.0;
+  jnt_offset[12] =  1.0;
+  jnt_offset[13] = -1.0;
+  jnt_offset[14] =  1.0;
+  jnt_offset[15] = -1.0;
+  jnt_offset[16] =  1.0;
+  jnt_offset[17] = -1.0;
+  jnt_offset[18] =  1.0;
+
+  AdaptiveSynergyTransmission trans(act_reduction,
+                                   jnt_reduction,
+                                   jnt_elastic,
+                                   jnt_offset);
+
+  EXPECT_EQ(1, trans.numActuators());
+  EXPECT_EQ(19, trans.numJoints());
+  EXPECT_EQ( 10.0, trans.getActuatorReduction()[0]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[0]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[1]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[2]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[3]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[4]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[5]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[6]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[7]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[8]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[9]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[10]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[11]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[12]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[13]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[14]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[15]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[16]);
+  EXPECT_EQ(-4.0, trans.getJointReduction()[17]);
+  EXPECT_EQ( 4.0, trans.getJointReduction()[18]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[0]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[1]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[2]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[3]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[4]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[5]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[6]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[7]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[8]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[9]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[10]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[11]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[12]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[13]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[14]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[15]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[16]);
+  EXPECT_EQ(-5.0, trans.getJointElastic()[17]);
+  EXPECT_EQ( 5.0, trans.getJointElastic()[18]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[0]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[1]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[2]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[3]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[4]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[5]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[6]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[7]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[8]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[9]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[10]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[11]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[12]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[13]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[14]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[15]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[16]);
+  EXPECT_EQ(-1.0, trans.getJointOffset()[17]);
+  EXPECT_EQ( 1.0, trans.getJointOffset()[18]);
+}
+
+class TransmissionSetup : public ::testing::Test
+{
+public:
+  TransmissionSetup()
+    : a_val(),
+      j_val(),
+      a_vec(vector<double*>(1)),
+      j_vec(vector<double*>(19))
+   {
+     a_vec[0] = &a_val[0];
+     j_vec[0] = &j_val[0];
+     j_vec[1] = &j_val[1];
+     j_vec[2] = &j_val[2];
+     j_vec[3] = &j_val[3];
+     j_vec[4] = &j_val[4];
+     j_vec[5] = &j_val[5];
+     j_vec[6] = &j_val[6];
+     j_vec[7] = &j_val[7];
+     j_vec[8] = &j_val[8];
+     j_vec[9] = &j_val[9];
+     j_vec[10] = &j_val[10];
+     j_vec[11] = &j_val[11];
+     j_vec[12] = &j_val[12];
+     j_vec[13] = &j_val[13];
+     j_vec[14] = &j_val[14];
+     j_vec[15] = &j_val[15];
+     j_vec[16] = &j_val[16];
+     j_vec[17] = &j_val[17];
+     j_vec[18] = &j_val[18];
+  }
+
+protected:
+  // Input/output transmission data
+  double a_val[1];
+  double j_val[19];
+  vector<double*> a_vec;
+  vector<double*> j_vec;
+};
+
+/// \brief Exercises the actuator->joint->actuator roundtrip, which should yield the identity map.
+class BlackBoxTest : public TransmissionSetup
+{
+protected:
+  /// \param trans Transmission instance.
+  /// \param ref_val Reference value (effort, velocity or position) that will be transformed with the respective forward
+  /// and inverse transmission transformations.
+  void testIdentityMap(AdaptiveSynergyTransmission& trans,
+                       const vector<double>& ref_val)
+  {
+    // Effort interface
+    {
+      ActuatorData a_data;
+      a_data.effort = a_vec;
+      *a_data.effort[0] = ref_val[0];
+
+      JointData j_data;
+      double* zero_ptr = new double(0.0);
+      j_data.position = vector<double*>( 19, zero_ptr ); // apply tests at home position for the joints
+      j_data.effort = j_vec;
+
+      trans.actuatorToJointEffort(a_data, j_data);
+
+      a_data.position = a_vec;
+      *a_data.position[0] = 0.0; // apply force at home position for actuator
+
+      trans.jointToActuatorEffort(j_data, a_data);
+      EXPECT_NEAR(ref_val[0], *a_data.effort[0], EPS);
+    }
+/*
+    // Velocity interface
+    {
+      ActuatorData a_data;
+      a_data.velocity = a_vec;
+      *a_data.velocity[0] = ref_val[0];
+
+      JointData j_data;
+      j_data.velocity = j_vec;
+
+      trans.actuatorToJointVelocity(a_data, j_data);
+      trans.jointToActuatorVelocity(j_data, a_data);
+      EXPECT_NEAR(ref_val[0], *a_data.velocity[0], EPS);
+    }
+*/
+    // Position interface
+    {
+      ActuatorData a_data;
+      a_data.position = a_vec;
+      *a_data.position[0] = ref_val[0];
+
+      JointData j_data;
+      j_data.position = j_vec;
+      double* zero_ptr = new double(0.0);
+      j_data.effort = vector<double*>( 19, zero_ptr ); // apply tests with no effort
+
+      trans.actuatorToJointPosition(a_data, j_data);
+      trans.jointToActuatorPosition(j_data, a_data);
+
+      EXPECT_NEAR(ref_val[0], *a_data.position[0], EPS);
+    }
+  }
+
+  /// Generate a set of transmission instances with random combinations of actuator/joint reduction and joint offset.
+  static vector<AdaptiveSynergyTransmission> createTestInstances(const vector<AdaptiveSynergyTransmission>::size_type size)
+  {
+    std::vector<AdaptiveSynergyTransmission> out;
+    out.reserve(size);
+    RandomDoubleGenerator rand_gen(-1.0, 1.0);                                // NOTE: Magic value
+
+    while (out.size() < size)
+    {
+      try
+      {
+        AdaptiveSynergyTransmission trans(randomVector(1, rand_gen),
+                                          randomVector(19, rand_gen),
+                                          randomVector(19, rand_gen),
+                                          randomVector(19, rand_gen));
+        out.push_back(trans);
+      }
+      catch(const TransmissionInterfaceException&)
+      {
+        // NOTE: If by chance a perfect zero is produced by the random number generator, construction will fail
+        // We swallow the exception and move on to prevent a test crash.
+      }
+    }
+    return out;
+  }
+};
+
+TEST_F(BlackBoxTest, IdentityMap)
+{
+  // Transmission instances
+  typedef vector<AdaptiveSynergyTransmission> TransList;
+  TransList trans_list = createTestInstances(100);                                  // NOTE: Magic value
+
+  // Test different transmission configurations...
+  for (TransList::iterator it = trans_list.begin(); it != trans_list.end(); ++it)
+  {
+    // ...and for each transmission, different input values
+    RandomDoubleGenerator rand_gen(-1.0, 1.0);                                // NOTE: Magic value
+    const unsigned int input_value_trials = 100;                                    // NOTE: Magic value
+    for (unsigned int i = 0; i < input_value_trials; ++i)
+    {
+      vector<double> input_value = randomVector(1, rand_gen);
+      testIdentityMap(*it, input_value);
+    }
+  }
+}
+
+
+class WhiteBoxTest : public TransmissionSetup {};
+
+TEST_F(WhiteBoxTest, DontMoveJoints)
+{
+  vector<double> actuator_reduction(1, 10.0);
+  vector<double> joint_reduction(19, 1.0);
+  vector<double> joint_elastic(19, 1.0);
+  vector<double> joint_offset(19, 0.0);
+
+  AdaptiveSynergyTransmission trans(actuator_reduction, joint_reduction, joint_elastic, joint_offset);
+
+  // Actuator input (used for effort, velocity and position)
+  *a_vec[0] = 0.0;
+
+  // Effort interface
+  {
+    ActuatorData a_data;
+    a_data.effort = a_vec;
+    
+    JointData j_data;
+    j_data.position = j_vec;
+    j_data.effort = j_vec;
+
+    trans.actuatorToJointEffort(a_data, j_data);
+    EXPECT_NEAR(0.0, *j_data.effort[0], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[1], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[2], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[3], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[4], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[5], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[6], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[7], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[8], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[9], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[10], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[11], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[12], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[13], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[14], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[15], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[16], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[17], EPS);
+    EXPECT_NEAR(0.0, *j_data.effort[18], EPS);
+
+  }
+
+  // Velocity interface
+  {
+    ActuatorData a_data;
+    a_data.velocity = a_vec;
+
+    JointData j_data;
+    j_data.velocity = j_vec;
+
+    trans.actuatorToJointVelocity(a_data, j_data);
+    EXPECT_NEAR(0.0, *j_data.velocity[0], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[1], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[2], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[3], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[4], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[5], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[6], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[7], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[8], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[9], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[10], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[11], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[12], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[13], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[14], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[15], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[16], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[17], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[18], EPS);
+  }
+
+  // Position interface
+  {
+    ActuatorData a_data;
+    a_data.position = a_vec;
+
+    JointData j_data;
+    j_data.position = j_vec;
+    j_data.effort = j_vec;
+
+    trans.actuatorToJointPosition(a_data, j_data);
+    EXPECT_NEAR(0.0, *j_data.position[0], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[1], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[2], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[3], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[4], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[5], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[6], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[7], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[8], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[9], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[10], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[11], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[12], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[13], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[14], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[15], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[16], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[17], EPS);
+    EXPECT_NEAR(0.0, *j_data.position[18], EPS);
+  }
+}
+
+TEST_F(WhiteBoxTest, MoveHand)
+{
+  vector<double> actuator_reduction(1, 10.0);
+  vector<double> joint_reduction(19, 1.0);
+  vector<double> joint_elastic(19, 1.0);
+  vector<double> joint_offset(19, 0.0);
+
+  AdaptiveSynergyTransmission trans(actuator_reduction, joint_reduction, joint_elastic, joint_offset);
+
+  // Effort interface
+  {
+    *a_vec[0] =  10.0;
+
+    ActuatorData a_data;
+    a_data.effort = a_vec;
+
+    JointData j_data;
+    j_data.position = j_vec;
+    j_data.effort = j_vec;
+
+    // If the actuator effort is 10x the reduction 10x, and the position remains the same, it means that,
+    // with 1.0 as joint reduction for everyone, you will have 100 effort in the joint
+    // this can be the situation for instance when in contact.
+    trans.actuatorToJointEffort(a_data, j_data);
+    EXPECT_NEAR(100.0, *j_data.effort[0], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[1], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[2], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[3], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[4], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[5], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[6], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[7], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[8], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[9], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[10], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[11], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[12], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[13], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[14], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[15], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[16], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[17], EPS);
+    EXPECT_NEAR(100.0, *j_data.effort[18], EPS);
+  }
+
+  // Velocity interface
+  {
+    *a_vec[0] = 10.0;
+
+    ActuatorData a_data;
+    a_data.velocity = a_vec;
+
+    JointData j_data;
+    j_data.position = j_vec;
+    j_data.velocity = j_vec;
+
+    // Attention, do not trust this test!!!
+    trans.actuatorToJointVelocity(a_data, j_data);
+    EXPECT_NEAR(0.0, *j_data.velocity[0], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[1], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[2], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[3], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[4], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[5], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[6], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[7], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[8], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[9], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[10], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[11], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[12], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[13], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[14], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[15], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[16], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[17], EPS);
+    EXPECT_NEAR(0.0, *j_data.velocity[18], EPS);
+
+  }
+
+  // Position interface
+  {
+    *a_vec[0] = 1.0;
+
+    double* zero_ptr = new double(0.0);
+
+    ActuatorData a_data;
+    a_data.position = a_vec;
+    a_data.effort = vector<double*>( 1, zero_ptr ); // a_vec;
+
+    JointData j_data;
+    j_data.position = j_vec;
+    j_data.effort = vector<double*>( 19, zero_ptr ); // apply the actuation position with zero effort at joints (no contact)
+    
+    // if you want to play with how the synergy work, assign a value different from zero at a desired joint
+    // as if it were making contact with the environment, and you will see how the other joints move
+    // of course the test will fail
+    double* value_ptr = new double(0.0);
+    j_data.effort[5] = value_ptr;
+
+    // if you move 1 in the actuator, you apply the reduction 10, and if all
+    // joint reductions are 1, you will have the joint positions equal to 
+    trans.actuatorToJointPosition(a_data, j_data);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[0], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[1], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[2], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[3], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[4], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[5], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[6], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[7], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[8], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[9], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[10], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[11], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[12], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[13], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[14], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[15], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[16], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[17], EPS);
+    EXPECT_NEAR(0.005263157894736842, *j_data.position[18], EPS);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/gazebo_ros_soft_hand/test/random_generator_utils.h
+++ b/gazebo_ros_soft_hand/test/random_generator_utils.h
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Adolfo Rodriguez Tsouroukdissian
+
+#ifndef RANDOM_GENERATOR_UTILS_H
+#define RANDOM_GENERATOR_UTILS_H
+
+#include <cstdlib>
+#include <ctime>
+#include <vector>
+
+using std::vector;
+
+/// \brief Generator of pseudo-random double in the range [min_val, max_val].
+// NOTE: Based on example code available at:
+// http://stackoverflow.com/questions/2860673/initializing-a-c-vector-to-random-values-fast
+struct RandomDoubleGenerator
+{
+public:
+  RandomDoubleGenerator(double min_val, double max_val)
+    : min_val_(min_val),
+      max_val_(max_val) {srand(time(NULL));}
+  double operator()()
+  {
+    const double range = max_val_ - min_val_;
+    return rand() / static_cast<double>(RAND_MAX) * range + min_val_;
+  }
+private:
+  double min_val_;
+  double max_val_;
+};
+
+/// \brief Generator of a vector of pseudo-random doubles.
+vector<double> randomVector(const vector<double>::size_type size, RandomDoubleGenerator& generator)
+{
+  vector<double> out;
+  out.reserve(size);
+  for (vector<double>::size_type i = 0; i < size; ++i) {out.push_back(generator());}
+  return out;
+}
+
+#endif // RANDOM_GENERATOR_UTILS_H

--- a/gazebo_ros_soft_hand/test/read_file.h
+++ b/gazebo_ros_soft_hand/test/read_file.h
@@ -1,0 +1,75 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Adolfo Rodriguez Tsouroukdissian
+
+#ifndef TRANSMISSION_INTERFACE_READ_FILE_H
+#define TRANSMISSION_INTERFACE_READ_FILE_H
+
+#include <string>
+#include <vector>
+#include <resource_retriever/retriever.h>
+#include <transmission_interface/transmission_info.h>
+#include <transmission_interface/transmission_parser.h>
+
+namespace transmission_interface
+{
+
+inline bool readFile(const std::string& filename, std::string& contents)
+{
+  resource_retriever::Retriever retriever;
+  resource_retriever::MemoryResource resource;
+
+  try
+  {
+     resource = retriever.get("package://transmission_interface/" + filename);
+  }
+  catch (resource_retriever::Exception& e)
+  {
+    ROS_ERROR("Failed to retrieve file: %s", e.what());
+    return false;
+  }
+
+  contents.assign(resource.data.get(), resource.data.get() + resource.size);
+  return true;
+}
+
+inline std::vector<TransmissionInfo> parseUrdf(const std::string& filename)
+{
+  std::vector<TransmissionInfo> infos;
+
+  std::string urdf;
+  if (!readFile(filename, urdf)) {return std::vector<TransmissionInfo>();}
+
+  TransmissionParser parser;
+  if (!parser.parse(urdf, infos)) {return std::vector<TransmissionInfo>();}
+  return infos;
+}
+
+} // namespace
+
+#endif // header guard

--- a/gazebo_ros_soft_hand/test/urdf/adaptive_synergy_transmission_loader_full.urdf
+++ b/gazebo_ros_soft_hand/test/urdf/adaptive_synergy_transmission_loader_full.urdf
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    <joint name="joint1">
+      <role>joint1</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint2">
+      <role>joint2</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint3">
+      <role>joint4</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint4">
+      <role>joint4</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint5">
+      <role>joint5</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint6">
+      <role>joint6</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint7">
+      <role>joint7</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint8">
+      <role>joint8</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint9">
+      <role>joint9</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint10">
+      <role>joint10</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint11">
+      <role>joint11</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint12">
+      <role>joint12</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint13">
+      <role>joint13</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint14">
+      <role>joint14</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint15">
+      <role>joint15</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint16">
+      <role>joint16</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint17">
+      <role>joint17</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint18">
+      <role>joint18</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <joint name="joint19">
+      <role>joint19</role>
+      <offset>-0.5</offset> <!--optional-->
+      <mechanicalReduction>2</mechanicalReduction> <!--optional-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+</robot>

--- a/gazebo_ros_soft_hand/test/urdf/adaptive_synergy_transmission_loader_invalid.urdf
+++ b/gazebo_ros_soft_hand/test/urdf/adaptive_synergy_transmission_loader_invalid.urdf
@@ -1,0 +1,1391 @@
+<?xml version="1.0"?>
+
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/DifferentialTransmission</type>
+    
+    <joint name="joint1">
+      <!-- <role>joint1</role> -->  <!-- Unspecified element-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+  
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>invalid_role</role> <!-- invalid role -->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role></role>   <!-- invalid role -->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="foo_actuator">
+      <!-- <role>actuator1</role> --> <!-- Unspecified element -->
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+
+
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>invalid_role</role> <!-- invalid role -->
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+
+
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <!-- <role></role> --> <!-- invalid role -->
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+<!-- 
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint2">   <!-- equal or repetition name -->
+<!--      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+-->
+
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <!-- <mechanicalReduction>30</mechanicalReduction> --> <!-- unspecified element -->
+    </actuator>
+  </transmission>
+
+
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>thirty</mechanicalReduction>  <!-- Not a number -->
+    </actuator>
+  </transmission>
+
+
+
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <mechanicalReduction>two</mechanicalReduction> <!--Not a Number-->
+      <mechanicalElasticity>3</mechanicalElasticity> <!--optional-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <mechanicalReduction>2</mechanicalReduction> 
+      <mechanicalElasticity>three</mechanicalElasticity> <!--Not a Number-->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+
+
+
+ <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <mechanicalReduction>0</mechanicalReduction>   <!-- invalid value -->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+
+
+
+ <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <offset>zero</offset>    <!-- not a number -->
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+</robot>

--- a/gazebo_ros_soft_hand/test/urdf/adaptive_synergy_transmission_loader_minimal.urdf
+++ b/gazebo_ros_soft_hand/test/urdf/adaptive_synergy_transmission_loader_minimal.urdf
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+
+<robot name="robot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <transmission name="adaptive_synergy_trans">
+    <type>transmission_interface/AdaptiveSynergyTransmission</type>
+    
+    <joint name="joint1">
+      <role>joint1</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint2">
+      <role>joint2</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint3">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint4">
+      <role>joint4</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint5">
+      <role>joint5</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint6">
+      <role>joint6</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint7">
+      <role>joint7</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint8">
+      <role>joint8</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint9">
+      <role>joint9</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint10">
+      <role>joint10</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint11">
+      <role>joint11</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint12">
+      <role>joint12</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint13">
+      <role>joint13</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint14">
+      <role>joint14</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint15">
+      <role>joint15</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint16">
+      <role>joint16</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint17">
+      <role>joint17</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint18">
+      <role>joint18</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+
+    <joint name="joint19">
+      <role>joint19</role>
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+  
+    <actuator name="foo_actuator">
+      <role>actuator1</role>
+      <mechanicalReduction>30</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+</robot>

--- a/soft_hand_description/model/soft_hand.transmission.xacro
+++ b/soft_hand_description/model/soft_hand.transmission.xacro
@@ -166,7 +166,7 @@
 
       <transmission name="${name}_joint_trans">
         <robotNamespace>${name}</robotNamespace>
-        <type>transmission_interface/AdaptiveSynergyTransmission</type>
+        <type>adaptive_transmission_interface/AdaptiveSynergyTransmission</type>
           <joint name="${name}_thumb_abd_joint">
             <role>joint1</role>
             <offset>-0.0</offset>

--- a/soft_hand_ros_control/src/soft_hand_hw.cpp
+++ b/soft_hand_ros_control/src/soft_hand_hw.cpp
@@ -377,9 +377,9 @@ namespace soft_hand_hw
 
         ROS_DEBUG_STREAM( "Number of devices: " << aux_int );
 
-        if(aux_int > 1 || aux_int < 0)
+        if(aux_int > 1 || aux_int <= 0)
         {
-          ROS_WARN("The current port has more than one or none device connected... that is not a SoftHand");
+          ROS_WARN_STREAM("The current port has " << aux_int << " devices connected, but it must be only one... that is not a SoftHand");
         }
         else
         {


### PR DESCRIPTION
This should solve the long-lasting issue of needing a forked version of [`ros_control`](https://github.com/CentroEPiaggio/ros_control) for using the SoftHand in simulation within Gazebo.

A local, specialized transmission is used instead to handle the adaptive case.

**IMPORTANT**: although everything has been ported, the [BlackBoxTest.IdentityMap](https://github.com/hamalMarino/pisa-iit-soft-hand/blob/pr-local-adaptive-transmission/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_test.cpp#L434) is NOT passing (and probably wasn't passing even before). This should be addressed later on.

I tested this in simulation with one or two hands, and with or without a Kuka LWR 4+ arm, and everything seems to work fine.

I will wait for testing this with the real robot: in the meanwhile every comment / suggestion is welcome.

/cc @carlosjoserg @arocchi 
