### PR TITLE
fixing transmission shared pointer type issue

### DIFF
--- a/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission_loader.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/adaptive_synergy_transmission_loader.h
@@ -50,7 +50,8 @@ using namespace transmission_interface;
 class AdaptiveSynergyTransmissionLoader : public TransmissionLoader
 {
 public:
-  TransmissionPtr load(const TransmissionInfo& transmission_info);
+
+  TransmissionSharedPtr load(const TransmissionInfo& transmission_info);
 
 private:
   static bool getActuatorConfig(const TransmissionInfo& transmission_info,

--- a/gazebo_ros_soft_hand/include/adaptive_transmission/loader_utils.h
+++ b/gazebo_ros_soft_hand/include/adaptive_transmission/loader_utils.h
@@ -33,7 +33,7 @@
 #include <transmission_interface/transmission_loader.h>
 
 using namespace transmission_interface;
-typedef TransmissionLoader::TransmissionPtr TransmissionPtr;
+//typedef TransmissionLoader::TransmissionPtr TransmissionPtr;
 
 
 struct TransmissionPluginLoader

--- a/gazebo_ros_soft_hand/src/adaptive_synergy_transmission_loader.cpp
+++ b/gazebo_ros_soft_hand/src/adaptive_synergy_transmission_loader.cpp
@@ -47,17 +47,17 @@ namespace adaptive_transmission_interface
 
 using namespace transmission_interface;
 
-AdaptiveSynergyTransmissionLoader::TransmissionPtr
+TransmissionSharedPtr  
 AdaptiveSynergyTransmissionLoader::load(const TransmissionInfo& transmission_info)
 {
   // Transmission should contain only one actuator/joint
-  if (!checkActuatorDimension(transmission_info, 1)) {return TransmissionPtr();}
-  if (!checkJointDimension(transmission_info,    19)) {return TransmissionPtr();}
+  if (!checkActuatorDimension(transmission_info, 1)) {return TransmissionSharedPtr();}
+  if (!checkJointDimension(transmission_info,    19)) {return TransmissionSharedPtr();}
 
   // Get actuator and joint configuration sorted by role: [actuator1] and [joint1,..., joint19]
   std::vector<double> act_reduction;
   const bool act_config_ok = getActuatorConfig(transmission_info, act_reduction);
-  if (!act_config_ok) {return TransmissionPtr();}
+  if (!act_config_ok) {return TransmissionSharedPtr();}
 
   std::vector<double> jnt_reduction;
   std::vector<double> jnt_elastic;
@@ -67,12 +67,12 @@ AdaptiveSynergyTransmissionLoader::load(const TransmissionInfo& transmission_inf
                                             jnt_elastic,
                                             jnt_offset);
 
-  if (!jnt_config_ok) {return TransmissionPtr();}
+  if (!jnt_config_ok) {return TransmissionSharedPtr();}
 
   // Transmission instance
   try
   {
-    TransmissionPtr transmission(new AdaptiveSynergyTransmission(act_reduction,
+    TransmissionSharedPtr transmission(new AdaptiveSynergyTransmission(act_reduction,
                                                               jnt_reduction,
                                                               jnt_elastic,
                                                               jnt_offset));
@@ -83,7 +83,7 @@ AdaptiveSynergyTransmissionLoader::load(const TransmissionInfo& transmission_inf
     using hardware_interface::internal::demangledTypeName;
     ROS_ERROR_STREAM_NAMED("parser", "Failed to construct transmission '" << transmission_info.name_ << "' of type '" <<
                            demangledTypeName<AdaptiveSynergyTransmission>()<< "'. " << ex.what());
-    return TransmissionPtr();
+    return TransmissionSharedPtr();
   }
 }
 

--- a/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
+++ b/gazebo_ros_soft_hand/src/default_soft_hand_hw_sim.cpp
@@ -70,7 +70,7 @@ bool DefaultSoftHandHWSim::initSim(
   
   assert(0 != transmission_loader);
 
-  TransmissionPtr transmission;
+  TransmissionSharedPtr transmission;
   const transmission_interface::TransmissionInfo& info = adaptive_trans_info;
   
   transmission = transmission_loader->load(info);

--- a/gazebo_ros_soft_hand/src/kinematic_ctrl_soft_hand_hw_sim.cpp
+++ b/gazebo_ros_soft_hand/src/kinematic_ctrl_soft_hand_hw_sim.cpp
@@ -101,7 +101,7 @@ bool KinematicCtrlSoftHandHWSim::initSim(
 
   assert(0 != transmission_loader);
 
-  TransmissionPtr transmission;
+  TransmissionSharedPtr transmission;
   const transmission_interface::TransmissionInfo& info = adaptive_trans_info;
   
   transmission = transmission_loader->load(info);

--- a/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_loader_test.cpp
+++ b/gazebo_ros_soft_hand/test/adaptive_synergy_transmission_loader_test.cpp
@@ -54,7 +54,7 @@ TEST(AdaptiveSynergyTransmissionLoaderTest, FullSpec)
   
   ASSERT_TRUE(0 != transmission_loader);
   
-  TransmissionPtr transmission;
+  TransmissionSharedPtr transmission;
   const TransmissionInfo& info = infos.front();
   
   transmission = transmission_loader->load(info);


### PR DESCRIPTION
TransmissionPtr changed to TransmissionSharedPtr, so it all compiles in ROS Kinetic.